### PR TITLE
Use relative default base path for Vite builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Aplicação React para planejar aportes mensais e metas patrimoniais. Pronta par
 2. Publique o conteúdo de `dist/` na branch `gh-pages`. Você pode usar GitHub Actions ou a CLI `gh-pages`.
 3. Garanta que o repositório esteja configurado para servir a branch `gh-pages` em `Settings > Pages`.
 
-O arquivo `vite.config.ts` já ajusta a base automaticamente usando a variável `GITHUB_REPOSITORY` do GitHub Actions. Para builds locais, defina `VITE_BASE_PATH="/Simulador-de-Investimentos/"` se publicar em um subcaminho diferente.
+O arquivo `vite.config.ts` já ajusta a base automaticamente usando a variável `GITHUB_REPOSITORY` do GitHub Actions e funciona localmente sem configurações extras. Só defina `VITE_BASE_PATH` se for publicar o build em um caminho incomum.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ const repoBase = process.env.GITHUB_REPOSITORY?.split("/")[1];
 
 export default defineConfig({
   plugins: [react()],
-  base: process.env.VITE_BASE_PATH ?? (repoBase ? `/${repoBase}/` : "/"),
+  base: process.env.VITE_BASE_PATH ?? (repoBase ? `/${repoBase}/` : "./"),
   build: {
     outDir: "dist",
     sourcemap: true


### PR DESCRIPTION
## Summary
- default the Vite base path to a relative value so local builds load assets without extra configuration
- refresh the README instructions to mention overriding the base path only for uncommon deployments

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68df422628dc8324ac38d3a67a1eaf90