### PR TITLE
Automate GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Aplicação React para planejar aportes mensais e metas patrimoniais. Pronta par
 
 ## Deploy no GitHub Pages
 
-1. Rode `npm install` e `npm run build`.
-2. Publique o conteúdo de `dist/` na branch `gh-pages`. Você pode usar GitHub Actions ou a CLI `gh-pages`.
-3. Garanta que o repositório esteja configurado para servir a branch `gh-pages` em `Settings > Pages`.
+Os commits em `main` já disparam um workflow que executa `npm run build` e publica automaticamente o conteúdo de `dist/` usando o GitHub Pages. Certifique-se apenas de manter o Pages configurado para a fonte **GitHub Actions** em `Settings > Pages`.
 
-O arquivo `vite.config.ts` já ajusta a base automaticamente usando a variável `GITHUB_REPOSITORY` do GitHub Actions. Para builds locais, defina `VITE_BASE_PATH="/Simulador-de-Investimentos/"` se publicar em um subcaminho diferente.
+Se preferir fazer o processo manualmente:
+
+1. Rode `npm install` e `npm run build`.
+2. Publique o conteúdo de `dist/` na branch `gh-pages` ou em outro host estático.
+
+O arquivo `vite.config.ts` já ajusta a base automaticamente usando a variável `GITHUB_REPOSITORY` do GitHub Actions e funciona localmente sem configurações extras. Só defina `VITE_BASE_PATH` se for publicar o build em um caminho incomum.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ const repoBase = process.env.GITHUB_REPOSITORY?.split("/")[1];
 
 export default defineConfig({
   plugins: [react()],
-  base: process.env.VITE_BASE_PATH ?? (repoBase ? `/${repoBase}/` : "/"),
+  base: process.env.VITE_BASE_PATH ?? (repoBase ? `/${repoBase}/` : "./"),
   build: {
     outDir: "dist",
     sourcemap: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the project and deploys it to GitHub Pages on every push to main
- document the automated deployment flow while keeping manual instructions for alternative hosting setups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df422628dc8324ac38d3a67a1eaf90